### PR TITLE
Add per-request dynamic headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,13 @@ module.exports = function(endpoint, opts) {
       if (hostInfo[1]) options.headers[opts.xforward.port || "x-forwarded-port"] = hostInfo[1];
     }
 
+    if (opts.header) {
+      var headers = opts.header();
+      Object.keys(headers).forEach(function(header) {
+        req.headers[header] = headers[header];
+      });
+    }
+
     /**
      * Hack for nginx backends where node, by default, sends no 'content-length'
      * header if no data is sent with the request and sets the 'transfer-encoding'

--- a/test/app.js
+++ b/test/app.js
@@ -7,6 +7,10 @@ var app = module.exports = express();
 
 app.use(require("connect-base")());
 
+app.get('/header', function(req, res, next) {
+  res.json(req.headers);
+});
+
 app.use(function(req, res, next) {
   res.send(req.base);
 });

--- a/test/simple-http-proxy.test.js
+++ b/test/simple-http-proxy.test.js
@@ -20,6 +20,11 @@ describe("simple-http-proxy", function(){
 
       app.use("/proxy", proxy(uri));
       app.use("/xforward", proxy(uri, {xforward: true}));
+      app.use("/header", proxy(uri+'/header', {
+        header: function() {
+          return {'Authorization': 'Bearer xyz123abc='};
+        }
+      }));
       done();
     });
   });
@@ -60,4 +65,17 @@ describe("simple-http-proxy", function(){
         done();
       });
   });
+
+  it("should allow dynamic custom headers", function(done) {
+    request(app)
+      .get("/header")
+      .expect(/Authorization/i)
+      .expect(/Bearer xyz123abc=/)
+      .end(function(err, res) {
+        if(err) return done(err);
+        if(!res.ok) return done(new Error(res.text));
+        done();
+      });
+  });
+
 });


### PR DESCRIPTION
Useful for adding server-held auth tokens to proxied requests.
